### PR TITLE
Application default credentials

### DIFF
--- a/Sources/GoogleAuth/DefaultCredentialsTokenProvider.swift
+++ b/Sources/GoogleAuth/DefaultCredentialsTokenProvider.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public struct DefaultCredentialsTokenProvider: TokenProvider {
+    public let tokenProvider: TokenProvider
+
+    // MARK: - Initializers
+
+    public init?(scopes: [String]) async {
+        do {
+            if let googleAppCredentials = ProcessInfo.processInfo.googleApplicationCredentials {
+                tokenProvider = try await ServiceAccountTokenProvider(
+                    serviceAccountPath: googleAppCredentials,
+                    scopes: scopes
+                )
+            } else if FileManager.default.fileExists(atPath: URL.applicationDefaultCredentialsJSON.path()) {
+                tokenProvider = try GoogleRefreshTokenProvider(
+                    credentialsPath: URL.applicationDefaultCredentialsJSON.path()
+                )
+            } else {
+                // TODO: Should use GoogleCloudMetadata provider in future
+                return nil
+            }
+        } catch {
+            return nil
+        }
+    }
+
+    // MARK: - Public interface
+
+    public func token() async throws(TokenProviderError) -> Token {
+        try await tokenProvider.token()
+    }
+}

--- a/Sources/GoogleAuth/ProcessInfoExtensions.swift
+++ b/Sources/GoogleAuth/ProcessInfoExtensions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+internal extension ProcessInfo {
+    var googleApplicationCredentials: String? {
+        environment["GOOGLE_APPLICATION_CREDENTIALS"]
+    }
+}

--- a/Tests/GoogleAuthTests/ServiceAccountTokenProviderTests.swift
+++ b/Tests/GoogleAuthTests/ServiceAccountTokenProviderTests.swift
@@ -3,9 +3,9 @@ import Foundation
 import Testing
 
 struct ServiceAccountTokenProviderTests {
-    @Test(.enabled(if: ProcessInfo.processInfo.environment["GOOGLE_APPLICATION_CREDENTIALS"] != nil))
+    @Test(.enabled(if: ProcessInfo.processInfo.googleApplicationCredentials != nil))
     func realToken() async throws {
-        let path = try #require(ProcessInfo.processInfo.environment["GOOGLE_APPLICATION_CREDENTIALS"])
+        let path = try #require(ProcessInfo.processInfo.googleApplicationCredentials)
         let provider = try await ServiceAccountTokenProvider(
             serviceAccountPath: path,
             scopes: ["https://www.googleapis.com/auth/devstorage.read_only"]


### PR DESCRIPTION
This PR implements [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials), not all of it, just `GOOGLE_APPLICATION_CREDENTIALS` with a service account and loading credentials from gcloud utility.