### PR TITLE
Implement quota project fields

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,12 +7,9 @@ on:
     branches:
       - main
 
-env:
-  DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
-
 jobs:
   tests:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
     - uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ All token providers share the same interface, so you just need to instantiate co
 try await provider.token()
 ```
 
+Once you get your token, it is recommended to use its helper function to modify required headers on your `URLRequest`
+
+```swift
+var request = URLRequest(url: url)
+token.add(to: &request)
+```
+
 Currently you can use 3 token providers, it is suggested to use `DefaultCredentialsTokenProvider` as it can be safely used in local and also in server environment.
 
 `DefaultCredentialsTokenProvider` implements part of [Google Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials). It internally uses `ServiceAccountTokenProvider` and `GoogleRefreshTokenProvider`.

--- a/Sources/GoogleAuth/GoogleRefreshTokenProvider/GoogleRefreshTokenProvider.swift
+++ b/Sources/GoogleAuth/GoogleRefreshTokenProvider/GoogleRefreshTokenProvider.swift
@@ -78,7 +78,8 @@ public actor GoogleRefreshTokenProvider: TokenProvider {
             accessToken: response.accessToken,
             tokenType: response.tokenType,
             issuedAt: iat,
-            expiresIn: response.expiresIn
+            expiresIn: response.expiresIn,
+            quotaProjectID: credentials.quotaProjectID
         )
 
         self.token = token

--- a/Sources/GoogleAuth/GoogleRefreshTokenProvider/RefreshCredentials.swift
+++ b/Sources/GoogleAuth/GoogleRefreshTokenProvider/RefreshCredentials.swift
@@ -4,10 +4,12 @@ internal struct RefreshCredentials: Decodable, Sendable {
         case clientSecret = "client_secret"
         case refreshToken = "refresh_token"
         case tokenType = "type"
+        case quotaProjectID = "quota_project_id"
     }
 
     let clientID: String
     let clientSecret: String
     let refreshToken: String
     let tokenType: String
+    let quotaProjectID: String?
 }

--- a/Sources/GoogleAuth/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
+++ b/Sources/GoogleAuth/ServiceAccountTokenProvider/ServiceAccountTokenProvider.swift
@@ -114,7 +114,8 @@ public actor ServiceAccountTokenProvider: TokenProvider {
             accessToken: response.accessToken,
             tokenType: response.tokenType,
             issuedAt: iat,
-            expiresIn: response.expiresIn
+            expiresIn: response.expiresIn,
+            quotaProjectID: nil
         )
 
         self.token = token

--- a/Sources/GoogleAuth/TokenProvider.swift
+++ b/Sources/GoogleAuth/TokenProvider.swift
@@ -16,10 +16,26 @@ public struct Token: Sendable, Codable, Hashable {
     public let issuedAt: Date
     /// Token expiration interval
     public let expiresIn: TimeInterval
-    
+    /// If this field is not-nil you are using [Application Default Credentials]() and you should include `x-goog-user-project`
+    ///
+    /// See more about setting billing at [Set billing project](https://cloud.google.com/docs/authentication/rest#set-billing-project)
+    public let quotaProjectID: String?
+
     /// Date of token expiration
     public var expiresAt: Date {
         issuedAt.addingTimeInterval(expiresIn)
+    }
+    
+    /// Sets appropriate headers to given request, basically `Authorization` and probably `x-goog-user-project`
+    /// - Parameter request: URL request to be modified
+    ///
+    /// If headers with same name were present, they will be overwritten.
+    public func add(to request: inout URLRequest) {
+        request.setValue(tokenType + " " + accessToken, forHTTPHeaderField: "Authorization")
+
+        if let quotaProjectID {
+            request.setValue(quotaProjectID, forHTTPHeaderField: "x-goog-user-project")
+        }
     }
 }
 

--- a/Tests/GoogleAuthTests/TokenTests.swift
+++ b/Tests/GoogleAuthTests/TokenTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+@testable import GoogleAuth
+import Testing
+
+struct TokenTests {
+    @Test(arguments: [
+        "quotaProjectID",
+        nil
+    ])
+    func requestHeaders(quotaProjectID: String?) throws {
+        let url = try #require(URL(string: "https://github.com"))
+        let token = Token(
+            accessToken: "accessToken",
+            tokenType: "tokenType",
+            issuedAt: .init(),
+            expiresIn: 3600,
+            quotaProjectID: quotaProjectID
+        )
+        var request = URLRequest(url: url)
+        token.add(to: &request)
+
+        var expectedRequest = URLRequest(url: url)
+        expectedRequest.setValue("tokenType accessToken", forHTTPHeaderField: "Authorization")
+
+        if let quotaProjectID {
+            expectedRequest.setValue(quotaProjectID, forHTTPHeaderField: "x-goog-user-project")
+        }
+
+        #expect(expectedRequest == request)
+    }
+}


### PR DESCRIPTION
If Application default credentials contain a quota project, it will be returned as part of `Token` object, so it can be used in `x-goog-user-project`.

For these `URLRequest` modifications there is added a helper function on `Token` that will set required headers.